### PR TITLE
converts roxygen to markdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ License: GPL-3 + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Depends: R (>= 3.5.0)
-Imports:  dplyr, 
+Imports: dplyr, 
     readr, 
     purrr, 
     tidygraph
@@ -21,4 +21,5 @@ Suggests:
     ggraph,
     BART
 VignetteBuilder: knitr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.0
+Roxygen: list(markdown = TRUE)

--- a/R/tidygraph-funs.R
+++ b/R/tidygraph-funs.R
@@ -1,15 +1,15 @@
 utils::globalVariables(c("new_node", "new_parent"))
 
-#' Get posterior tree draws into \code{tbl_graph} format from \code{tidygraph} package.
+#' Get posterior tree draws into `tbl_graph` format from `tidygraph` package.
 #'
-#' Creates a list of \code{tbl_graph}'s. Each element of list corresponds to a particular MCMC iteration (\code{iter}) and tree id (\code{tree_id}).
-#' See \link[tidygraph]{tbl_graph} for details.
+#' Creates a list of `tbl_graph`'s. Each element of list corresponds to a particular MCMC iteration (`iter`) and tree id (`tree_id`).
+#' See [tbl_graph][tidygraph::tbl_graph] for details.
 #'
 #' @param model BART model.
 #' @param extra_cols Extra columns to be included.
 #' @param label_digits Rounding for labels.
 #'
-#' @return List of \code{tbl_graph}.
+#' @return List of `tbl_graph`.
 #'
 #' @export
 as_tidygraph_list <- function(model, extra_cols, label_digits = 2){

--- a/R/tidytree-funs.R
+++ b/R/tidytree-funs.R
@@ -1,28 +1,28 @@
-#' Get posterior tree draws into \code{tbl_tree} format from \code{tidytree} package.
+#' Get posterior tree draws into `tbl_tree` format from `tidytree` package.
 #'
-#' Creates a \code{tbl_tree} grouped by iteration (\code{iter}) and tree id (\code{tree_id}).
+#' Creates a `tbl_tree` grouped by iteration (`iter`) and tree id (`tree_id`).
 #' See Details below.
 #'
 #' @param model BART model.
 #' @param extra_cols Extra columns to be included.
 #' @param label_digits Rounding for labels.
 #'
-#' @return A tibble with required columns for \code{tbl_tree}:
-#'   \code{node}, \code{parent}, \code{label}.
-#'   And columns \code{iter}, \code{tree_id} are used to differentiate trees and iterations and are always included.
+#' @return A tibble with required columns for `tbl_tree`:
+#'   `node`, `parent`, `label`.
+#'   And columns `iter`, `tree_id` are used to differentiate trees and iterations and are always included.
 #'   Remaining columns are optional (see details).
 #'
 #' @details List of potential columns returned:
 #'   \describe{
 #'   \item{iter}{Integer describing unique MCMC iteration.}
-#'   \item{tree_id}{Integer. Unique tree id with each \code{iter}.}
-#'   \item{node}{Integer describing node in tree. Unique to each \code{tree}-\code{iter}.}
+#'   \item{tree_id}{Integer. Unique tree id with each `iter`.}
+#'   \item{node}{Integer describing node in tree. Unique to each `tree`-`iter`.}
 #'   \item{parent}{Integer describing parent node in tree.}
 #'   \item{label}{Label for the node.}
 #'   \item{tier}{Position in tree hierarchy.}
 #'   \item{var}{Variable for split.}
-#'   \item{cut}{Numeric. Value of decision rule for \code{var}.}
-#'   \item{is_leaf}{Logical. \code{TRUE} if leaf, \code{FALSE} if stem.}
+#'   \item{cut}{Numeric. Value of decision rule for `var`.}
+#'   \item{is_leaf}{Logical. `TRUE` if leaf, `FALSE` if stem.}
 #'   \item{leaf_value}{Numeric (mean function) value of leaf}
 #'   \item{child_left}{Integer. Left child of node.}
 #'   \item{child_right}{Integer. Right child of node.}

--- a/R/tree-extract-BART.R
+++ b/R/tree-extract-BART.R
@@ -2,23 +2,23 @@ utils::globalVariables(c("node", "var", "leaf", "unique_tree_id", "iter", "tree_
 
 #' Get posterior tree draws into tibble format
 #'
-#' Tibble grouped by iteration (\code{iter}) and tree id (\code{tree_id}).
+#' Tibble grouped by iteration (`iter`) and tree id (`tree_id`).
 #' All information calculated by method is included in output.
-#' See \code{as_tidytree} for more user-friendly method.
+#' See `as_tidytree` for more user-friendly method.
 #'
 #' @param model BART model.
 #' @param label_digits Rounding for labels.
 #'
 #' @return A tibble with columns to \describe{
 #'   \item{iter}{Integer describing unique MCMC iteration.}
-#'   \item{tree_id}{Integer. Unique tree id with each \code{iter}.}
-#'   \item{node}{Integer describing node in tree. Unique to each \code{tree}-\code{iter}.}
+#'   \item{tree_id}{Integer. Unique tree id with each `iter`.}
+#'   \item{node}{Integer describing node in tree. Unique to each `tree`-`iter`.}
 #'   \item{parent}{Integer describing parent node in tree.}
 #'   \item{label}{Label for the node.}
 #'   \item{tier}{Position in tree hierarchy.}
 #'   \item{var}{Variable for split.}
-#'   \item{cut}{Numeric. Value of decision rule for \code{var}.}
-#'   \item{is_leaf}{Logical. \code{TRUE} if leaf, \code{FALSE} if stem.}
+#'   \item{cut}{Numeric. Value of decision rule for `var`.}
+#'   \item{is_leaf}{Logical. `TRUE` if leaf, `FALSE` if stem.}
 #'   \item{leaf_value}{}
 #'   \item{child_left}{Integer. Left child of node.}
 #'   \item{child_right}{Integer. Right child of node.}

--- a/man/as_tidygraph_list.Rd
+++ b/man/as_tidygraph_list.Rd
@@ -18,5 +18,5 @@ List of \code{tbl_graph}.
 }
 \description{
 Creates a list of \code{tbl_graph}'s. Each element of list corresponds to a particular MCMC iteration (\code{iter}) and tree id (\code{tree_id}).
-See \link[tidygraph]{tbl_graph} for details.
+See \link[tidygraph:tbl_graph]{tbl_graph} for details.
 }

--- a/man/as_tidytree.Rd
+++ b/man/as_tidytree.Rd
@@ -15,9 +15,9 @@ as_tidytree(model, extra_cols, label_digits = 2)
 }
 \value{
 A tibble with required columns for \code{tbl_tree}:
-  \code{node}, \code{parent}, \code{label}.
-  And columns \code{iter}, \code{tree_id} are used to differentiate trees and iterations and are always included.
-  Remaining columns are optional (see details).
+\code{node}, \code{parent}, \code{label}.
+And columns \code{iter}, \code{tree_id} are used to differentiate trees and iterations and are always included.
+Remaining columns are optional (see details).
 }
 \description{
 Creates a \code{tbl_tree} grouped by iteration (\code{iter}) and tree id (\code{tree_id}).
@@ -25,18 +25,18 @@ See Details below.
 }
 \details{
 List of potential columns returned:
-  \describe{
-  \item{iter}{Integer describing unique MCMC iteration.}
-  \item{tree_id}{Integer. Unique tree id with each \code{iter}.}
-  \item{node}{Integer describing node in tree. Unique to each \code{tree}-\code{iter}.}
-  \item{parent}{Integer describing parent node in tree.}
-  \item{label}{Label for the node.}
-  \item{tier}{Position in tree hierarchy.}
-  \item{var}{Variable for split.}
-  \item{cut}{Numeric. Value of decision rule for \code{var}.}
-  \item{is_leaf}{Logical. \code{TRUE} if leaf, \code{FALSE} if stem.}
-  \item{leaf_value}{Numeric (mean function) value of leaf}
-  \item{child_left}{Integer. Left child of node.}
-  \item{child_right}{Integer. Right child of node.}
-  }
+\describe{
+\item{iter}{Integer describing unique MCMC iteration.}
+\item{tree_id}{Integer. Unique tree id with each \code{iter}.}
+\item{node}{Integer describing node in tree. Unique to each \code{tree}-\code{iter}.}
+\item{parent}{Integer describing parent node in tree.}
+\item{label}{Label for the node.}
+\item{tier}{Position in tree hierarchy.}
+\item{var}{Variable for split.}
+\item{cut}{Numeric. Value of decision rule for \code{var}.}
+\item{is_leaf}{Logical. \code{TRUE} if leaf, \code{FALSE} if stem.}
+\item{leaf_value}{Numeric (mean function) value of leaf}
+\item{child_left}{Integer. Left child of node.}
+\item{child_right}{Integer. Right child of node.}
+}
 }

--- a/man/eatmyshorts.Rd
+++ b/man/eatmyshorts.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{eatmyshorts}
 \alias{eatmyshorts}
-\alias{eatmyshorts-package}
 \title{eatmyshorts: Visualisation for BART models}
 \description{
 Visualisation methods and functions for exploring Bayesian Additive Regression Trees

--- a/man/get_posterior_trees.Rd
+++ b/man/get_posterior_trees.Rd
@@ -13,19 +13,19 @@ get_posterior_trees(model, label_digits = 2)
 }
 \value{
 A tibble with columns to \describe{
-  \item{iter}{Integer describing unique MCMC iteration.}
-  \item{tree_id}{Integer. Unique tree id with each \code{iter}.}
-  \item{node}{Integer describing node in tree. Unique to each \code{tree}-\code{iter}.}
-  \item{parent}{Integer describing parent node in tree.}
-  \item{label}{Label for the node.}
-  \item{tier}{Position in tree hierarchy.}
-  \item{var}{Variable for split.}
-  \item{cut}{Numeric. Value of decision rule for \code{var}.}
-  \item{is_leaf}{Logical. \code{TRUE} if leaf, \code{FALSE} if stem.}
-  \item{leaf_value}{}
-  \item{child_left}{Integer. Left child of node.}
-  \item{child_right}{Integer. Right child of node.}
-  }
+\item{iter}{Integer describing unique MCMC iteration.}
+\item{tree_id}{Integer. Unique tree id with each \code{iter}.}
+\item{node}{Integer describing node in tree. Unique to each \code{tree}-\code{iter}.}
+\item{parent}{Integer describing parent node in tree.}
+\item{label}{Label for the node.}
+\item{tier}{Position in tree hierarchy.}
+\item{var}{Variable for split.}
+\item{cut}{Numeric. Value of decision rule for \code{var}.}
+\item{is_leaf}{Logical. \code{TRUE} if leaf, \code{FALSE} if stem.}
+\item{leaf_value}{}
+\item{child_left}{Integer. Left child of node.}
+\item{child_right}{Integer. Right child of node.}
+}
 }
 \description{
 Tibble grouped by iteration (\code{iter}) and tree id (\code{tree_id}).


### PR DESCRIPTION
so now you can write, `` `tbl_graph` `` instead of `\code{tbl_graph}`
